### PR TITLE
Add structured Rust tutorials

### DIFF
--- a/sections/async-programming/README.md
+++ b/sections/async-programming/README.md
@@ -1,0 +1,42 @@
+# Async Programming – async, await, Futures, tokio, async-std
+
+## Overview
+Asynchronous programming in Rust enables handling many tasks concurrently without blocking threads. The `async` and `await` keywords work with `Future` objects, representing values that may not be available yet. Popular runtime crates like `tokio` and `async-std` provide executors and utilities for writing asynchronous code.
+
+## Detailed Explanation
+### Futures
+A `Future` is a trait that produces a value asynchronously. Futures are lazy; nothing happens until they are polled by an executor. The `async` keyword creates a state machine implementing `Future` under the hood.
+
+### `async`/`await`
+Functions marked `async` return a `Future`. Using `await` pauses execution until the future is ready, yielding control back to the executor so it can run other tasks.
+
+### Async Runtimes
+`tokio` and `async-std` are the most widely used runtimes. They schedule and run futures on event loops, provide I/O, timing, and synchronization primitives tailored for asynchronous environments.
+
+## Code Examples
+```rust
+use tokio::time::{sleep, Duration};
+
+async fn say_after(delay: u64, msg: &str) {
+    sleep(Duration::from_secs(delay)).await;
+    println!("{msg}");
+}
+
+#[tokio::main]
+async fn main() {
+    let hello = say_after(2, "hello");
+    let world = say_after(1, "world");
+    tokio::join!(hello, world);
+}
+```
+
+## Common Pitfalls & Warnings
+- **Blocking in async**: Calling blocking operations inside `async` functions can stall the executor. Use async-aware versions (`tokio::fs`, `tokio::task::spawn_blocking`).
+- **Runtime mismatch**: Futures created for one runtime (e.g., tokio) may not run on another without compatibility features.
+
+## Best Practices
+- Structure asynchronous code as small tasks to keep the event loop responsive.
+- Choose a single runtime for your project to avoid compatibility issues.
+
+## Mini Exercise
+Implement an async function that fetches two URLs concurrently using `reqwest` and prints the length of the responses. Run it with `tokio::main`.

--- a/sections/building-projects/README.md
+++ b/sections/building-projects/README.md
@@ -1,0 +1,53 @@
+# Building Projects – CLI tools, REST APIs, WASM, and game engines (bevy)
+
+## Overview
+Rust’s ecosystem supports diverse application domains. You can build command-line tools, web services, WebAssembly (WASM) modules, and games using frameworks like Bevy. This section highlights the key concepts and crates involved in these areas.
+
+## Detailed Explanation
+### CLI Tools
+`clap` or `argh` help you parse command-line arguments and options. Combine them with `structopt` for deriving argument parsing from struct definitions. `cargo install` lets you distribute CLI binaries easily.
+
+### REST APIs
+Frameworks such as `actix-web` and `axum` allow building fast, type-safe web services. They integrate with `serde` for JSON serialization and `tokio` for async operations.
+
+### WebAssembly
+Rust compiles to WASM via `wasm32-unknown-unknown` target. Tools like `wasm-bindgen` facilitate interaction between Rust and JavaScript. WASM is ideal for high-performance web apps or running Rust in browsers.
+
+### Game Engines
+Bevy is an ECS (Entity Component System) game engine written in Rust. It provides cross-platform rendering, audio, and input support. You write systems in Rust and rely on Bevy’s scheduler to manage them.
+
+## Code Examples
+```rust
+// CLI example with clap
+use clap::Parser;
+#[derive(Parser)]
+struct Args { name: String }
+fn main() {
+    let args = Args::parse();
+    println!("Hello, {}!", args.name);
+}
+```
+
+```rust
+// Basic REST API using axum
+use axum::{routing::get, Router};
+#[tokio::main]
+async fn main() {
+    let app = Router::new().route("/", get(|| async { "Hello" }));
+    axum::Server::bind(&"0.0.0.0:3000".parse().unwrap())
+        .serve(app.into_make_service())
+        .await
+        .unwrap();
+}
+```
+
+## Common Pitfalls & Warnings
+- **Target confusion**: Building for WASM or other platforms requires the correct target triple (`wasm32-unknown-unknown`, etc.).
+- **Binary size**: Minimize release binary size by using `--release` and features like `strip` or `opt-level`.
+
+## Best Practices
+- Use `cargo new --bin` for CLI projects and `cargo generate` for templates when starting larger applications.
+- Separate business logic from I/O code for easier testing and maintenance.
+
+## Mini Exercise
+Create a simple CLI program that accepts a `--name` argument and prints a personalized greeting. Then, modify it to compile to WebAssembly using `wasm-pack` and run it in a web page.

--- a/sections/collections-and-iterators/README.md
+++ b/sections/collections-and-iterators/README.md
@@ -1,0 +1,49 @@
+# Collections and Iterators – Vectors, HashMaps, Iterators, Functional Methods
+
+## Overview
+Rust offers powerful standard collections and iterator tools. Vectors and HashMaps are dynamic, growable structures, while iterators provide lazy sequences that can be transformed through functional methods like `map`, `filter`, and `fold`. This combination enables expressive and efficient data manipulation.
+
+## Detailed Explanation
+### Vectors
+Vectors (`Vec<T>`) are resizable arrays. They store elements contiguously in memory and grow as needed. Methods like `push`, `pop`, and indexing make them versatile for dynamic lists.
+
+### HashMaps
+`HashMap<K, V>` stores key-value pairs. Keys must implement `Eq` and `Hash`. HashMaps provide efficient lookup, insertion, and removal operations.
+
+### Iterators
+Iterators represent a sequence of values. The `Iterator` trait defines methods like `next`, but higher-level adapters allow chaining transformations. Many collections offer iterator creation via `iter()`, `iter_mut()`, or `into_iter()`.
+
+## Code Examples
+```rust
+use std::collections::HashMap;
+
+fn main() {
+    let mut numbers = vec![1, 2, 3];
+    numbers.push(4);
+    for n in &numbers {
+        println!("{n}");
+    }
+
+    let mut scores = HashMap::new();
+    scores.insert("alice", 10);
+    scores.insert("bob", 8);
+
+    if let Some(score) = scores.get("alice") {
+        println!("alice: {score}");
+    }
+
+    let sum: i32 = numbers.iter().map(|x| x * 2).sum();
+    println!("sum = {sum}");
+}
+```
+
+## Common Pitfalls & Warnings
+- **HashMap iteration order**: Iteration order is undefined; don’t rely on insertion order.
+- **Iterator consumption**: Calling iterator methods like `collect` or `sum` consumes the iterator; it cannot be reused without re-creating it.
+
+## Best Practices
+- Use iterator chains for concise and expressive data processing.
+- Prefer `Vec` over arrays for dynamic collections, and reserve `HashMap` for associative lookups.
+
+## Mini Exercise
+Create a vector of integers from 1 to 10. Use iterator methods to filter out the even numbers, square the remaining ones, and collect the results into a new vector. Print the final vector.

--- a/sections/concurrency-and-multithreading/README.md
+++ b/sections/concurrency-and-multithreading/README.md
@@ -1,0 +1,51 @@
+# Concurrency and Multithreading – Threads, Channels, Arc, Mutex
+
+## Overview
+Rust’s fearless concurrency model ensures thread safety at compile time. Using the standard library, you can spawn threads, communicate between them with channels, and share data safely with `Arc` and `Mutex`. These primitives enable building concurrent programs without data races.
+
+## Detailed Explanation
+### Threads
+Threads are created with `std::thread::spawn`, executing a closure in parallel with the current thread. Ownership rules extend across threads; data must be `Send` to move into a new thread and `Sync` to share immutable references.
+
+### Channels
+Channels provide message passing between threads. A sender transmits values to a receiver, allowing synchronization without shared state. Use `std::sync::mpsc` for multi-producer, single-consumer channels.
+
+### Arc and Mutex
+`Arc<T>` is an atomically reference-counted pointer that allows multiple threads to own the same data. `Mutex<T>` provides interior mutability with locking. Combining `Arc<Mutex<T>>` gives shared, mutable access across threads.
+
+## Code Examples
+```rust
+use std::sync::{Arc, Mutex, mpsc};
+use std::thread;
+
+fn main() {
+    let counter = Arc::new(Mutex::new(0));
+    let (tx, rx) = mpsc::channel();
+    let mut handles = vec![];
+
+    for _ in 0..5 {
+        let counter = Arc::clone(&counter);
+        let tx = tx.clone();
+        let handle = thread::spawn(move || {
+            let mut num = counter.lock().unwrap();
+            *num += 1;
+            tx.send(*num).unwrap();
+        });
+        handles.push(handle);
+    }
+
+    for handle in handles { handle.join().unwrap(); }
+    for received in rx { println!("count = {received}"); }
+}
+```
+
+## Common Pitfalls & Warnings
+- **Deadlocks**: Locking order of mutexes can cause deadlocks. Keep critical sections small and consistent.
+- **Cloning channels**: Cloning the transmitter increases the number of senders. Dropping all senders is required to close the channel and allow the receiver to exit loops.
+
+## Best Practices
+- Use channels for communicating state rather than sharing mutable data when possible.
+- Prefer `Arc<Mutex<T>>` for shared mutable data, but consider `RwLock` for scenarios with many readers and few writers.
+
+## Mini Exercise
+Modify the example to spawn 10 threads that each increment the shared counter five times. Send the final value from each thread over the channel and print the sequence of received values.

--- a/sections/control-flow/README.md
+++ b/sections/control-flow/README.md
@@ -1,0 +1,55 @@
+# Control Flow – if, match, loops, conditionals
+
+## Overview
+Control flow lets you dictate how your program executes based on conditions or repetition. Rust provides familiar constructs like `if`/`else`, pattern matching with `match`, and looping mechanisms such as `loop`, `while`, and `for`. These tools allow you to express branching logic and repetition in a type-safe manner.
+
+## Detailed Explanation
+### `if` Statements
+`if` expressions evaluate to a boolean and execute a block if true. They can include an `else` block or chain with `else if`. Because `if` is an expression, it can be used in variable bindings.
+
+### `match` Statements
+`match` offers powerful pattern matching, evaluating an expression and executing code for the first matching arm. Patterns can destructure enums, tuples, or primitives, ensuring exhaustive coverage at compile time.
+
+### Loops
+- **`loop`**: Runs indefinitely until you explicitly `break` out.
+- **`while`**: Continues while a condition evaluates to true.
+- **`for`**: Iterates over an iterator (like ranges or collections) and is the most idiomatic for fixed loops.
+
+## Code Examples
+```rust
+fn main() {
+    let number = 7;
+    if number % 2 == 0 {
+        println!("even");
+    } else {
+        println!("odd");
+    }
+
+    match number {
+        1 => println!("one"),
+        2 | 3 | 5 | 7 | 11 => println!("prime"),
+        _ => println!("something else"),
+    }
+
+    for i in 0..3 {
+        println!("i = {i}");
+    }
+
+    let mut count = 0;
+    while count < 3 {
+        println!("count = {count}");
+        count += 1;
+    }
+}
+```
+
+## Common Pitfalls & Warnings
+- **Forgetting `break` in a `loop`**: Without a terminating condition, `loop` will run forever.
+- **Non-exhaustive `match` arms**: The compiler will prevent missing cases, but using `_` for catch-all may hide unexpected values.
+
+## Best Practices
+- Prefer `for` loops when iterating over collections.
+- Use pattern matching with `match` for enums instead of complex `if` chains.
+
+## Mini Exercise
+Write a program that iterates through numbers 1 to 20. For multiples of 3, print “Fizz”; for multiples of 5, print “Buzz”; for numbers divisible by both, print “FizzBuzz”. Use a `for` loop and `match` statement together to perform the checks.

--- a/sections/error-handling/README.md
+++ b/sections/error-handling/README.md
@@ -1,0 +1,47 @@
+# Error Handling – Result, Option, ?, Custom Errors
+
+## Overview
+Rust emphasizes explicit error handling through the `Result` and `Option` types. `Result` is used for recoverable errors, while `Option` represents the presence or absence of a value. The `?` operator simplifies propagating errors, and you can create custom error types to provide richer context.
+
+## Detailed Explanation
+### `Result<T, E>`
+`Result` is an enum with variants `Ok(T)` and `Err(E)`. Functions that may fail return `Result`, forcing the caller to handle success or failure explicitly. Pattern matching or the `?` operator can be used to extract values.
+
+### `Option<T>`
+`Option` has `Some(T)` and `None` variants. It indicates the absence of a value without resorting to `null` pointers. Pattern matching or methods like `unwrap_or` and `map` help handle `Option` safely.
+
+### The `?` Operator
+The `?` operator returns early if the `Result` is `Err`, automatically converting compatible error types. It helps reduce boilerplate when propagating errors.
+
+### Custom Errors
+Custom error types implement `std::error::Error` and usually derive `Debug` and `Display`. Libraries like `thiserror` can simplify creating them.
+
+## Code Examples
+```rust
+use std::{fs::File, io::{self, Read}};
+
+fn read_username() -> Result<String, io::Error> {
+    let mut file = File::open("username.txt")?;
+    let mut contents = String::new();
+    file.read_to_string(&mut contents)?;
+    Ok(contents)
+}
+
+fn main() {
+    match read_username() {
+        Ok(name) => println!("Username: {name}"),
+        Err(e) => eprintln!("Error: {e}")
+    }
+}
+```
+
+## Common Pitfalls & Warnings
+- **Unwrapping without care**: Using `unwrap()` on `Result` or `Option` will panic on failure; avoid it in production code.
+- **Ignoring errors**: The compiler warns if a `Result` is unused. Use `let _ =` only when ignoring is truly intentional.
+
+## Best Practices
+- Propagate errors with `?` for readability.
+- Use custom error types to provide context and implement `From` for automatic conversions.
+
+## Mini Exercise
+Write a function that parses integers from a string, returning `Result<Vec<i32>, std::num::ParseIntError>`. Use `?` to handle potential parsing errors and test the function with valid and invalid input.

--- a/sections/generics-and-traits/README.md
+++ b/sections/generics-and-traits/README.md
@@ -1,0 +1,69 @@
+# Generics and Traits – Generics, Traits, Trait Bounds, Polymorphism
+
+## Overview
+Generics and traits allow you to write flexible, reusable code. Generics parameterize types so functions and structs can work with any type that meets certain bounds. Traits define shared behavior and enable polymorphism across different types.
+
+## Detailed Explanation
+### Generics
+Generic functions or structs use type parameters like `T` to represent any type. The compiler monomorphizes generics at compile time, creating concrete implementations for each used type, so there is no runtime cost.
+
+### Traits
+Traits are collections of methods that define behavior. Types implement traits to opt into that behavior. Standard traits like `Display`, `Debug`, and `Clone` are used throughout the standard library. Traits can also include default method implementations.
+
+### Trait Bounds
+To restrict generic types, you specify trait bounds using syntax like `T: Display`. Multiple bounds use the `+` operator. Where clauses (`where T: Display`) can enhance readability for complex bounds.
+
+### Polymorphism
+Rust uses trait objects (`dyn Trait`) for dynamic dispatch when you need runtime polymorphism. This incurs a small runtime cost and requires traits to be object-safe.
+
+## Code Examples
+```rust
+use std::fmt::Display;
+
+fn largest<T: PartialOrd + Copy>(list: &[T]) -> T {
+    let mut largest = list[0];
+    for &item in list.iter() {
+        if item > largest {
+            largest = item;
+        }
+    }
+    largest
+}
+
+trait Summary {
+    fn summarize(&self) -> String;
+}
+
+struct News {
+    headline: String,
+}
+
+impl Summary for News {
+    fn summarize(&self) -> String {
+        format!("News: {}", self.headline)
+    }
+}
+
+fn notify(item: &impl Summary) {
+    println!("{}", item.summarize());
+}
+
+fn main() {
+    let numbers = vec![1, 3, 2];
+    println!("largest = {}", largest(&numbers));
+
+    let news = News { headline: String::from("Rust 1.70 Released!") };
+    notify(&news);
+}
+```
+
+## Common Pitfalls & Warnings
+- **Trait object safety**: Not all traits can be turned into trait objects. Methods that use `Self` in their signatures or are generic themselves are not object-safe.
+- **Complex bounds**: Overly verbose bounds can reduce readability; consider using `where` clauses.
+
+## Best Practices
+- Keep trait interfaces small and focused.
+- Use generics to reduce code duplication, but don’t over-generalize if only one type is expected.
+
+## Mini Exercise
+Define a trait `Area` with a method `area(&self) -> f64`. Implement it for a `Rectangle { width: f64, height: f64 }` and a `Circle { radius: f64 }`. Write a function that takes a slice of trait objects `&[&dyn Area]` and prints the area of each shape.

--- a/sections/introduction-to-rust/README.md
+++ b/sections/introduction-to-rust/README.md
@@ -1,0 +1,54 @@
+# Introduction to Rust – Installing Rust and Writing Your First Program
+
+## Overview
+Rust is a modern systems programming language focused on safety and performance. It eliminates entire classes of bugs by enforcing strict compile-time checks, while also providing low-level control similar to C or C++. Getting started requires installing the Rust toolchain and writing a simple program to understand the basic workflow. This section walks you through the installation process and demonstrates how to compile and run a basic program.
+
+## Detailed Explanation
+Rust uses the `rustup` tool to manage versions and associated utilities like `cargo`—Rust’s package manager and build system. Once installed, you can create new projects or compile single files. The compiler enforces memory safety without needing a garbage collector, leading to predictable performance. Compiled binaries are statically linked by default, making deployment straightforward across environments.
+
+### How It Works
+1. Install `rustup`, which includes the Rust compiler (`rustc`) and `cargo`.
+2. Use `cargo new` to create a new project. This generates a `Cargo.toml` manifest and a sample `src/main.rs`.
+3. Run `cargo build` or `cargo run` to compile and execute your program. Cargo handles dependency resolution, compilation, and running tests.
+
+### Importance
+Rust’s installation and workflow are the gateway to the language’s unique benefits. Compared to scripting languages, Rust requires a compile step, but in exchange you get type safety, memory safety, and optimized performance. Cargo’s integration of dependency management, testing, and build scripts fosters a streamlined experience similar to high-level languages but with the power of low-level control.
+
+## Code Examples
+```bash
+# Install rustup (Linux/macOS)
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+```bash
+# Windows (PowerShell)
+Invoke-WebRequest -Uri https://sh.rustup.rs -UseBasicParsing | Invoke-Expression
+```
+
+```bash
+# Create and run a new project
+cargo new hello_rust
+cd hello_rust
+cargo run
+```
+
+```rust
+// src/main.rs
+fn main() {
+    println!("Hello, Rust!");
+}
+```
+
+## Common Pitfalls & Warnings
+- **Skipping `rustup`**: Installing Rust via other methods can lead to outdated toolchains. Always use `rustup` unless using a system package specifically managed by your organization.
+- **Forgetting to update**: Run `rustup update` periodically to stay current with the stable release.
+
+## Best Practices
+- Use `cargo run` during development for quick feedback.
+- Keep your toolchain up to date, but lock versions for production builds using `rust-toolchain.toml`.
+
+## Mini Exercise
+1. Install Rust using `rustup`.
+2. Create a project named `greeting` with `cargo new`.
+3. Modify `src/main.rs` so the program prints your own custom greeting.
+4. Build and run the program with `cargo run`.

--- a/sections/lifetimes/README.md
+++ b/sections/lifetimes/README.md
@@ -1,0 +1,42 @@
+# Lifetimes – Lifetime annotations, elision rules, real-world use cases
+
+## Overview
+Lifetimes are Rust’s way of ensuring that references remain valid. They describe the scope for which a reference is valid and prevent dangling pointers. While many lifetimes are inferred, some situations require explicit annotations to disambiguate how long references should live.
+
+## Detailed Explanation
+### Lifetime Annotations
+Lifetimes are written using apostrophe syntax like `'a`. Functions that accept references with potentially different lifetimes may need annotations to relate them. For instance, `fn longest<'a>(x: &'a str, y: &'a str) -> &'a str` tells the compiler that the returned reference will live as long as both input references.
+
+### Elision Rules
+Rust has three lifetime elision rules that allow omitting explicit lifetimes in common cases:
+1. Each parameter that is a reference gets its own lifetime parameter.
+2. If there is exactly one input lifetime, that lifetime is assigned to all output lifetimes.
+3. If there are multiple input lifetimes but one of them is `&self` or `&mut self`, the lifetime of `self` is assigned to all output lifetimes.
+
+### Real-World Use Cases
+Lifetimes appear often in functions returning references to data passed in or stored in structs with references. They also surface in iterator implementations and asynchronous code where references span multiple scopes.
+
+## Code Examples
+```rust
+fn longest<'a>(x: &'a str, y: &'a str) -> &'a str {
+    if x.len() > y.len() { x } else { y }
+}
+
+fn main() {
+    let s1 = String::from("abcd");
+    let s2 = "xyz";
+    let result = longest(&s1, s2);
+    println!("Longest: {result}");
+}
+```
+
+## Common Pitfalls & Warnings
+- **Dangling references**: The compiler will prevent returning a reference that outlives its source data.
+- **Over-specifying lifetimes**: Adding unnecessary lifetime annotations can make code harder to read; rely on elision rules when possible.
+
+## Best Practices
+- Start by writing code without explicit lifetimes and add them only when the compiler requires it.
+- Name lifetimes meaningfully in complex scenarios (`'a`, `'b`) to clarify relationships between references.
+
+## Mini Exercise
+Write a struct `Book<'a>` containing a reference to a `str` title. Implement a method `announce(&self)` that prints the title. Instantiate a `Book` and call `announce()` to demonstrate how lifetimes enable borrowing data from the outside.

--- a/sections/macros-and-metaprogramming/README.md
+++ b/sections/macros-and-metaprogramming/README.md
@@ -1,0 +1,52 @@
+# Macros and Metaprogramming – macro_rules!, procedural macros, derive
+
+## Overview
+Macros extend Rust’s syntax, enabling code generation and metaprogramming. Declarative macros (`macro_rules!`) let you write pattern-matching rules that expand into code. Procedural macros operate on the abstract syntax tree, providing custom derives, attributes, or function-like macros.
+
+## Detailed Explanation
+### `macro_rules!`
+Declarative macros use pattern matching to transform input tokens into Rust code. They are defined with `macro_rules!` and expanded at compile time. Each rule matches an invocation pattern and replaces it with generated code.
+
+### Procedural Macros
+Procedural macros are functions that receive Rust code as input and output new code. They come in three forms:
+1. **Derive macros**: Used with `#[derive]` to automatically implement traits.
+2. **Attribute macros**: Modify the item they’re attached to.
+3. **Function-like macros**: Look like function calls but operate on tokens.
+These macros require a dedicated crate with the `proc-macro` attribute.
+
+## Code Examples
+```rust
+// Declarative macro
+macro_rules! repeat {
+    ($val:expr, $times:expr) => {{
+        let mut v = Vec::new();
+        for _ in 0..$times { v.push($val); }
+        v
+    }};
+}
+
+fn main() {
+    let values = repeat!(1, 3);
+    println!("{:?}", values);
+}
+```
+
+```rust
+// Procedural macro crate (simplified)
+use proc_macro::TokenStream;
+#[proc_macro_attribute]
+pub fn my_attr(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    item
+}
+```
+
+## Common Pitfalls & Warnings
+- **Debugging difficulty**: Macro expansions can be hard to read. Use `cargo expand` to inspect the generated code.
+- **Compilation errors**: Macros run at compile time; errors inside them can produce cryptic messages.
+
+## Best Practices
+- Keep macros small and focused on removing boilerplate.
+- Prefer regular functions or traits when they suffice; macros should be a last resort for code generation.
+
+## Mini Exercise
+Create a simple `vec_of_strings!` declarative macro that takes any number of expressions and returns a `Vec<String>` by calling `.to_string()` on each argument.

--- a/sections/modules-and-packages/README.md
+++ b/sections/modules-and-packages/README.md
@@ -1,0 +1,50 @@
+# Modules and Packages – Modules, Crates, Cargo, Visibility
+
+## Overview
+Modules and packages organize Rust code into reusable units. A package is a collection of crates, where a crate is the smallest compilable unit. Modules declare namespaces within a crate and control visibility using the `pub` keyword. Cargo orchestrates building, testing, and publishing crates.
+
+## Detailed Explanation
+### Crates and Packages
+A crate can be a binary or library. Packages specify one or more crates in a `Cargo.toml` file. Cargo compiles each crate separately and links them together. The root of a binary crate is usually `src/main.rs`, while a library crate has `src/lib.rs`.
+
+### Modules
+Modules allow you to group items (functions, structs, enums) into a namespace. By default, everything is private; adding `pub` exposes items to other modules or crates. Modules can be nested in subdirectories using `mod` declarations.
+
+### Visibility
+`pub` makes an item public to other modules or crates, `pub(crate)` restricts it to the current crate, and `pub(super)` exposes it to the parent module. Controlling visibility helps maintain encapsulation and prevents unintended dependencies.
+
+## Code Examples
+```rust
+// src/main.rs
+mod network; // declares a submodule in src/network.rs
+
+fn main() {
+    network::connect();
+}
+```
+
+```rust
+// src/network.rs
+pub fn connect() {
+    println!("connected");
+}
+```
+
+```toml
+# Cargo.toml
+[package]
+name = "my_app"
+version = "0.1.0"
+edition = "2021"
+```
+
+## Common Pitfalls & Warnings
+- **Forgetting `mod`**: Declaring a module requires a corresponding `mod` statement, or the file will not be compiled.
+- **Overexposing internals**: Be mindful of what you mark `pub` to avoid a brittle API surface.
+
+## Best Practices
+- Keep modules small and focused; create submodules for separate concerns.
+- Use `cargo doc --open` to generate and review documentation for your crates.
+
+## Mini Exercise
+Create a binary crate with a module named `greetings` that exposes a public function `hello()` returning a `String`. Call this function from `main` and print the result.

--- a/sections/ownership-and-borrowing/README.md
+++ b/sections/ownership-and-borrowing/README.md
@@ -1,0 +1,54 @@
+# Ownership and Borrowing – The ownership model, borrowing, references
+
+## Overview
+Ownership is Rust’s core concept for managing memory safety without a garbage collector. Each value has a single owner; when the owner goes out of scope, the value is dropped. Borrowing allows references to data without transferring ownership, enabling safe concurrency and reducing unnecessary copies.
+
+## Detailed Explanation
+### Ownership Rules
+1. Each value in Rust has a variable that’s called its owner.
+2. There can be only one owner at a time.
+3. When the owner goes out of scope, the value is dropped.
+
+### Borrowing
+Borrowing occurs when you pass references to data (`&T` for immutable, `&mut T` for mutable). While references are active, the original owner cannot be moved or, in the case of immutable references, mutated. The compiler checks these rules at compile time, preventing data races and dangling pointers.
+
+### Why It’s Important
+Unlike languages with garbage collectors, Rust’s ownership model enables deterministic resource management and zero-cost abstractions. Compared to manual memory management, it removes entire classes of bugs like double frees or memory leaks.
+
+## Code Examples
+```rust
+fn main() {
+    let s = String::from("hello");
+    takes_ownership(s); // s is moved here and is no longer valid
+
+    let x = 5;
+    makes_copy(x); // x is Copy, so it’s still usable after the call
+
+    let mut s2 = String::from("borrow");
+    change(&mut s2); // mutable borrow
+    println!("{s2}");
+}
+
+fn takes_ownership(some_string: String) {
+    println!("{some_string}");
+} // some_string is dropped here
+
+fn makes_copy(some_int: i32) {
+    println!("{some_int}");
+}
+
+fn change(s: &mut String) {
+    s.push_str(" me");
+}
+```
+
+## Common Pitfalls & Warnings
+- **Dangling references**: The compiler won’t allow returning references to values created inside the function because they’ll be dropped at the end.
+- **Mutable aliasing**: You cannot have more than one mutable reference to a value in the same scope, nor a mutable reference while immutable references exist.
+
+## Best Practices
+- Favor references over cloning large data structures to avoid unnecessary allocations.
+- Use Rust’s ownership system to manage resources beyond memory, such as file handles or network sockets.
+
+## Mini Exercise
+Write a function `first_word(s: &str) -> &str` that returns a slice of the first word in a string. Test it by borrowing a `String` and ensuring that the original string remains usable afterward.

--- a/sections/rust-in-production/README.md
+++ b/sections/rust-in-production/README.md
@@ -1,0 +1,50 @@
+# Rust in Production – Tooling (clippy, fmt, cargo-audit, CI/CD tips)
+
+## Overview
+Using Rust in production requires robust tooling for code quality and security. Tools like `rustfmt` for formatting, `clippy` for linting, and `cargo-audit` for dependency vulnerability scanning help maintain high standards. Integrating these tools into continuous integration (CI) pipelines ensures consistency and reliability.
+
+## Detailed Explanation
+### rustfmt
+`rustfmt` automatically formats your code according to style guidelines. Run `cargo fmt` to apply formatting across the project. Consistent formatting improves readability and reduces noise in code reviews.
+
+### clippy
+`clippy` is a collection of lints that catch common mistakes and suggest idiomatic Rust patterns. Invoke it with `cargo clippy`. Pay attention to warnings about performance or suspicious code.
+
+### cargo-audit
+`cargo-audit` scans `Cargo.lock` for crates with known vulnerabilities. It uses the RustSec advisory database and warns if updates are needed to keep dependencies secure.
+
+### CI/CD Tips
+- Add `cargo fmt -- --check` and `cargo clippy -- -D warnings` to your CI pipeline to enforce formatting and linting.
+- Run `cargo test` and `cargo audit` as part of automated checks before deploying.
+- Use tools like GitHub Actions or GitLab CI for cross-platform testing and releases.
+
+## Code Examples
+```yaml
+# Example GitHub Actions snippet
+name: Rust CI
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - run: cargo fmt -- --check
+      - run: cargo clippy -- -D warnings
+      - run: cargo test
+      - run: cargo audit || true
+```
+
+## Common Pitfalls & Warnings
+- **Ignoring lint warnings**: Treat `clippy` warnings seriously; they often point to real issues.
+- **CI drift**: Ensure your local environment matches CI toolchains to avoid unexpected build failures.
+
+## Best Practices
+- Keep `Cargo.lock` checked in for applications to ensure reproducible builds.
+- Automate checks in CI to catch issues early and maintain code health over time.
+
+## Mini Exercise
+Set up a minimal GitHub Actions workflow that runs `cargo fmt -- --check` and `cargo test` on every push. Experiment by adding `clippy` and `cargo-audit` steps.

--- a/sections/rust-internals/README.md
+++ b/sections/rust-internals/README.md
@@ -1,0 +1,40 @@
+# Rust Internals – MIR, borrow checker internals, trait resolution
+
+## Overview
+Understanding Rust’s internals offers deeper insight into how the language works. The Mid-level Intermediate Representation (MIR) is used by the compiler for borrow checking and optimization. The borrow checker enforces memory safety through dataflow analysis, while trait resolution determines how generic functions are instantiated.
+
+## Detailed Explanation
+### MIR
+MIR sits between the high-level AST and low-level LLVM IR. It simplifies the program into a control-flow graph, enabling optimizations and precise borrow checking. You can inspect MIR using `rustc --emit=mir`.
+
+### Borrow Checker Internals
+The borrow checker operates on MIR, tracking lifetimes of references and ensuring they don’t overlap in conflicting ways. It uses dataflow algorithms to enforce rules such as no mutable aliasing and validity of references.
+
+### Trait Resolution
+When you call a method on a generic type, the compiler resolves which trait implementation applies by examining trait bounds and where clauses. It uses a system known as coherence to ensure there’s at most one applicable implementation in scope.
+
+## Code Examples
+```rust
+fn example() {
+    let mut x = 5;
+    let y = &x; // immutable borrow
+    let z = &mut x; // ERROR: cannot borrow `x` as mutable because it is also borrowed as immutable
+    println!("{y} {z}");
+}
+```
+
+To inspect MIR, run:
+```bash
+rustc --emit=mir src/main.rs -O
+```
+
+## Common Pitfalls & Warnings
+- **Borrow checker misunderstandings**: Errors can be confusing at first. Use compiler flags like `-Z borrowck=mir` (nightly) for extra debugging information.
+- **Trait coherence conflicts**: Implementing a foreign trait for a foreign type is disallowed (the orphan rule) to prevent conflicting implementations.
+
+## Best Practices
+- Read the official Rustonomicon for deeper insights into unsafe code and internals.
+- Experiment with nightly features in small projects to learn how the compiler works, but avoid them in production without stability guarantees.
+
+## Mini Exercise
+Compile a small program with `rustc --emit=mir` and inspect the generated `.mir` files. Identify the control-flow structure for a simple `if` statement and see how variables are represented.

--- a/sections/structs-and-enums/README.md
+++ b/sections/structs-and-enums/README.md
@@ -1,0 +1,62 @@
+# Structs and Enums – Structs, Enums, Pattern Matching
+
+## Overview
+Structs and enums allow you to create custom data types in Rust. Structs group related fields together, while enums represent a value that can be one of several variants. Pattern matching with `match` enables ergonomic handling of these user-defined types.
+
+## Detailed Explanation
+### Structs
+Structs are similar to structs in C or classes without methods in other languages. They let you organize data into named fields. Rust also has tuple structs and unit-like structs for different use cases.
+
+### Enums
+Enums define a type by enumerating its possible variants. Variants can be unit-like, tuple-like, or struct-like, each potentially holding different data. Enums are often paired with pattern matching to handle different variants.
+
+### Pattern Matching
+Using `match`, you can destructure structs and enums, binding their inner data to variables. The compiler ensures that all possible variants are handled.
+
+## Code Examples
+```rust
+struct User {
+    username: String,
+    email: String,
+    active: bool,
+}
+
+enum Message {
+    Quit,
+    Move { x: i32, y: i32 },
+    Write(String),
+    ChangeColor(i32, i32, i32),
+}
+
+fn process(msg: Message) {
+    match msg {
+        Message::Quit => println!("Quit"),
+        Message::Move { x, y } => println!("move to ({x}, {y})"),
+        Message::Write(text) => println!("{text}"),
+        Message::ChangeColor(r, g, b) => println!("color = ({r}, {g}, {b})"),
+    }
+}
+
+fn main() {
+    let user = User {
+        username: String::from("alice"),
+        email: String::from("alice@example.com"),
+        active: true,
+    };
+    println!("{}", user.username);
+
+    let msg = Message::Move { x: 10, y: 20 };
+    process(msg);
+}
+```
+
+## Common Pitfalls & Warnings
+- **Uninitialized struct fields**: All fields must be initialized when creating a struct instance.
+- **Missing match arms**: When matching on enums, the compiler forces exhaustive matches to avoid undefined behavior.
+
+## Best Practices
+- Use `derive(Debug)` for structs and enums when debugging or logging.
+- Prefer enums over complicated boolean flags to represent distinct states.
+
+## Mini Exercise
+Create an enum `Shape` with variants `Circle(f64)` and `Rectangle{width: f64, height: f64}`. Write a function `area` that returns the area of a shape. Use pattern matching to calculate areas for both variants.

--- a/sections/testing-and-debugging/README.md
+++ b/sections/testing-and-debugging/README.md
@@ -1,0 +1,59 @@
+# Testing and Debugging – Unit tests, integration tests, benchmarking, dbg!, cargo test
+
+## Overview
+Testing and debugging are integral to reliable software. Rust’s tooling provides built-in support for unit tests, integration tests, and benchmarking. The `dbg!` macro offers quick insight into values during development. The `cargo test` command orchestrates compiling and running tests automatically.
+
+## Detailed Explanation
+### Unit Tests
+Placed in the same file as the code they test, unit tests focus on small, isolated functionality. They are annotated with `#[test]` and run with `cargo test`.
+
+### Integration Tests
+These tests reside in the `tests` directory and exercise your library’s public API as a whole. Each file is compiled as a separate crate, ensuring only public items are accessible.
+
+### Benchmarking
+With the `criterion` crate or unstable built-in features, you can measure performance over time. Benchmarks are executed with `cargo bench`.
+
+### Debugging with `dbg!`
+The `dbg!` macro prints a value along with the file and line number, returning ownership of the expression. It’s handy for quick inspection during development.
+
+## Code Examples
+```rust
+// src/lib.rs
+pub fn add(a: i32, b: i32) -> i32 { a + b }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_add() {
+        assert_eq!(add(2, 3), 5);
+    }
+}
+```
+
+```rust
+// tests/integration_test.rs
+use my_crate::add;
+
+#[test]
+fn it_works() {
+    assert_eq!(add(1, 2), 3);
+}
+```
+
+```rust
+// Using dbg!
+let value = dbg!(some_function());
+```
+
+## Common Pitfalls & Warnings
+- **Ignoring test failures**: `cargo test` runs all tests; if one fails, inspect the output to diagnose rather than ignoring it.
+- **Debug-only code**: Remember to remove or disable `dbg!` calls before final release builds.
+
+## Best Practices
+- Keep unit tests small and focused on one behavior.
+- Use integration tests to cover public APIs and external behavior.
+
+## Mini Exercise
+Create a library crate with a function `square(n: i32) -> i32`. Write a unit test verifying that `square(4)` equals `16` and an integration test calling the public function. Run the tests using `cargo test`.

--- a/sections/unsafe-rust-and-ffi/README.md
+++ b/sections/unsafe-rust-and-ffi/README.md
@@ -1,0 +1,50 @@
+# Unsafe Rust and FFI – unsafe, raw pointers, FFI with C
+
+## Overview
+Rust’s `unsafe` keyword enables operations that bypass the compiler’s usual guarantees, allowing low-level memory manipulation and interoperability with foreign languages like C. Used carefully, it unlocks capabilities otherwise impossible in safe Rust.
+
+## Detailed Explanation
+### `unsafe` Blocks
+Inside an `unsafe` block, you can dereference raw pointers, call `unsafe` functions, access mutable statics, and perform other unchecked operations. The `unsafe` keyword tells the compiler that you, the programmer, uphold the necessary invariants.
+
+### Raw Pointers
+Raw pointers (`*const T`, `*mut T`) are similar to C pointers. They can be created from references using `as` casts, but accessing or dereferencing them is only allowed within `unsafe` blocks.
+
+### FFI with C
+Rust can interface with C code using the `extern` keyword and `#[link]` attributes. You define function signatures that match the C ABI and link against the appropriate library.
+
+## Code Examples
+```rust
+extern "C" {
+    fn abs(input: i32) -> i32;
+}
+
+fn main() {
+    unsafe {
+        let val = abs(-3);
+        println!("abs(-3) = {val}");
+    }
+}
+```
+
+```rust
+// Raw pointer usage
+let mut num = 5;
+let r1 = &num as *const i32;
+let r2 = &mut num as *mut i32;
+unsafe {
+    println!("{}", *r1);
+    *r2 = 10;
+}
+```
+
+## Common Pitfalls & Warnings
+- **Undefined behavior**: Misusing `unsafe` can cause memory corruption or crashes. Limit the scope of `unsafe` code and document invariants.
+- **FFI mismatch**: Incorrect signatures or calling conventions when interfacing with C can lead to subtle bugs.
+
+## Best Practices
+- Encapsulate `unsafe` code in safe abstractions so callers don’t need to use `unsafe` themselves.
+- Use crates like `bindgen` to generate bindings for C libraries automatically.
+
+## Mini Exercise
+Write an `unsafe` function `split_at_mut` that takes a mutable slice and splits it into two mutable slices at a given index. Ensure it maintains aliasing rules by using raw pointers internally.

--- a/sections/variables-and-data-types/README.md
+++ b/sections/variables-and-data-types/README.md
@@ -1,0 +1,47 @@
+# Variables and Data Types – Variables, Constants, Shadowing, Primitive Types
+
+## Overview
+Rust enforces strict rules around variable binding and data types to ensure safety and predictability. Variables are immutable by default, though they can be declared mutable. Shadowing allows redeclaring a variable name, while constants provide globally accessible values that cannot change. Rust’s primitive types include integers, floating-point numbers, booleans, characters, and tuples.
+
+## Detailed Explanation
+Variables in Rust are immutable unless declared with `mut`. This eliminates many accidental mutations. Shadowing introduces a new variable with the same name, allowing transformation or type changes. Constants are always immutable and must have type annotations. Rust’s type system is static but includes type inference when possible.
+
+### Primitive Types
+- **Integers**: `i8`, `u8`, `i16`, `u16`, `i32`, `u32`, `i64`, `u64`, `i128`, `u128`, `isize`, `usize`.
+- **Floating Point**: `f32`, `f64`.
+- **Boolean**: `bool`.
+- **Character**: `char` (Unicode scalar value).
+- **Compound Types**: tuples and arrays.
+
+The compiler checks for overflow in debug mode and panics when it occurs; in release mode, overflow wraps around by default.
+
+## Code Examples
+```rust
+fn main() {
+    let x = 5;           // immutable
+    let mut y = 10;      // mutable
+    y += 5;              // y is now 15
+
+    const SECONDS_IN_DAY: u32 = 60 * 60 * 24;
+
+    let x = x * 2;       // shadowing; x becomes 10
+    println!("x = {}, y = {}", x, y);
+    println!("There are {SECONDS_IN_DAY} seconds in a day");
+
+    // tuple destructuring
+    let point: (i32, i32) = (3, 4);
+    let (x_coord, y_coord) = point;
+    println!("({x_coord}, {y_coord})");
+}
+```
+
+## Common Pitfalls & Warnings
+- **Uninitialized variables**: Rust will not compile code where a variable might be used before being initialized.
+- **Shadowing vs. mutability confusion**: Shadowing creates a new binding; it does not make a variable mutable. Attempting to mutate after shadowing without `mut` will fail.
+
+## Best Practices
+- Prefer immutability; only use `mut` when necessary.
+- Name constants in screaming snake case (`UPPER_CASE_WITH_UNDERSCORES`).
+
+## Mini Exercise
+Write a program that declares a mutable variable `count`, increments it inside a loop until it reaches 5, and prints the value on each iteration. Try shadowing `count` with a new binding that doubles its value, then print the result.


### PR DESCRIPTION
## Summary
- add tutorial sections for mastering Rust from beginner to advanced
- topics include installation, ownership, modules, error handling, generics, async, macros, unsafe code, production tips, and internals

## Testing
- `cargo test` *(fails: could not find `Cargo.toml`)*

------
https://chatgpt.com/codex/tasks/task_e_684d02e563588326afc793e6f8606ff9